### PR TITLE
Replaced |Vector g s| by |Vector s g|.

### DIFF
--- a/L/04/W04.lhs
+++ b/L/04/W04.lhs
@@ -659,7 +659,7 @@ and
 Two homomorphisms which are inverse of each other define an
 \emph{isomorphism}.
 %
-If an isomorphism exist between two sets, we say that they are
+If an isomorphism exists between two sets, we say that they are
 isomorphic.
 %
 For example, the exponential and the logarithm witness an isomorphism

--- a/L/07/W07.lhs
+++ b/L/07/W07.lhs
@@ -936,7 +936,7 @@ our basis vectors |e i|.
 For example, |p x = 2+x^3| is represented by |2 *^ e 0 + e 3|.
 %
 
-The evaluator from the |Vector g s| representation to polynomial
+The evaluator from the |Vector s g| representation to polynomial
 functions is as follows:
 %
 %if False


### PR DESCRIPTION
This is probably the only place in W07.lhs in which the arguments are flipped, I haven't checked the other chapters.