### PR TITLE
Switched quotation marks that looked like the second derivative

### DIFF
--- a/L/04/E4.lhs
+++ b/L/04/E4.lhs
@@ -374,8 +374,8 @@ The evaluation of the second derivative is given by
 \end{spec}
 %
 \begin{enumerate}[label=\alph*)]
-\item Let |P(h) = | ``|h| is a homomorphism from |FunExp| to
-  |FunSem = REAL -> REAL|''.
+\item Let |P(h) = | "|h| is a homomorphism from |FunExp| to
+  |FunSem = REAL -> REAL|".
   %
   Express |P| in logic and show |not P(eval'')|.
 


### PR DESCRIPTION
Either this, or another way to make this clear. At the moment, the quotation marks make it look like the second derivative, especially since this chapter discusses just that - the second derivative.

This is a quick fix however might not be desirable, but a clarification needs to be made here to make it easier to understand that it is a string and not something to do with the second derivative.